### PR TITLE
Added Dockerfile for compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# ============================================
+# Dockerfile for STM32F103 Firmware Build Only
+# ============================================
+
+# Base image — lightweight Ubuntu
+FROM ubuntu:22.04
+
+# -----------------------------
+# Install build dependencies
+# -----------------------------
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \       
+    gcc-arm-none-eabi \ 
+    libnewlib-arm-none-eabi \                       
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------
+# Set working directory inside container
+# -----------------------------
+WORKDIR /workspace
+
+# -----------------------------
+# Notes:
+# - Firmware source code and Makefile will be mounted at runtime
+#   with: 
+#       docker run --rm -v ${PWD}:/workspace -w /workspace/firmware stm32devboardcompiler make all
+# - Container is purely for reproducible compilation
+# - To clean build artifacts, run:
+#       docker run --rm -v ${PWD}:/workspace -w /workspace/firmware stm32devboardcompiler make clean all
+# -----------------------------

--- a/README.md
+++ b/README.md
@@ -177,3 +177,7 @@ See the `LICENSE` file for details.
 * Multi-device testing support
 * Hardware fault injection
 * Coverage reporting and test data visualization
+* Linting and SCA of Embedded Code
+* Add I2C and UART communcation
+* Add automated testing with logic analyzer
+* ccache in Docker for faster builds


### PR DESCRIPTION

## 📝 Dockerfile Overview

This Dockerfile provides a **minimal, reproducible build environment** for STM32F103 firmware projects. It packages the ARM GCC toolchain and required libraries into a lightweight Ubuntu container, ensuring consistent builds across different machines.

### 🔧 Key Components
- **Base Image**: `ubuntu:22.04` (stable, lightweight).
- **Dependencies Installed**:
  - `build-essential` → includes `make` and core build tools.
  - `gcc-arm-none-eabi` → ARM cross‑compiler for STM32.
  - `libnewlib-arm-none-eabi` → embedded C library headers (e.g. `stdio.h`).
- **Working Directory**: `/workspace` (your project is mounted here at runtime).

### ⚙️ Usage
Run builds directly inside the container:
```powershell
docker run --rm -v ${PWD}:/workspace -w /workspace/firmware stm32devboardcompiler make all
```

- Mounts your project into `/workspace`.
- Runs `make all` inside the `firmware` folder.
- Outputs build artifacts (`.elf`, `.hex`, `.bin`) into `firmware/build` on your host.

For a clean rebuild:
```powershell
docker run --rm -v ${PWD}:/workspace -w /workspace/firmware stm32devboardcompiler make clean all
```

### 🚀 Benefits
- **Reproducibility**: Same toolchain and libraries everywhere.
- **Portability**: Works on Windows, macOS, and Linux without local toolchain installs.
- **Simplicity**: Minimal dependencies, focused only on compilation.

